### PR TITLE
Rodar único teste no github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Run tests
+on: 
+  push:
+    branches:
+    - master
+  pull_request: 
+    branches:
+    - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run tests
+      run: |
+        npm run testes


### PR DESCRIPTION
Percebi que existe um comando "testes" que basicamente tenta interpretar o arquivo `tests/tests.egua` . 
Acho que podemos conversar numa issue para melhorar a cobertura de testes. 

Eu preferi criar um novo arquivo do github actions pra conseguir configurar os testes pra rodar também em pull requests. Diferente do arquivo `main.yml` que só faz deploy quando é feito o merge. 