### PR TITLE
Método mapear() em Egualib

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "REPL",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "console": "integratedTerminal",
+            "program": "${workspaceFolder}\\index.js"
+        }
+    ]
+}

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -1,17 +1,17 @@
-const tokenTypes = require("./tokenTypes.js");
-const Environment = require("./environment.js");
-const Egua = require("./egua.js");
-const loadGlobalLib = require("./lib/globalLib.js");
-const path = require("path");
-const fs = require("fs");
-const checkStdLib = require("./lib/importStdlib.js");
+const tokenTypes = require("./tokenTypes.js"),
+    Environment = require("./environment.js"),
+    Egua = require("./egua.js"),
+    loadGlobalLib = require("./lib/globalLib.js"),
+    path = require("path"),
+    fs = require("fs"),
+    checkStdLib = require("./lib/importStdlib.js");
 
-const Callable = require("./structures/callable.js");
-const StandardFn = require("./structures/standardFn.js");
-const EguaClass = require("./structures/class.js");
-const EguaFunction = require("./structures/function.js");
-const EguaInstance = require("./structures/instance.js");
-const EguaModule = require("./structures/module.js");
+const Callable = require("./structures/callable.js"),
+    StandardFn = require("./structures/standardFn.js"),
+    EguaClass = require("./structures/class.js"),
+    EguaFunction = require("./structures/function.js"),
+    EguaInstance = require("./structures/instance.js"),
+    EguaModule = require("./structures/module.js");
 
 const {
     RuntimeError,
@@ -29,7 +29,7 @@ module.exports = class Interpreter {
         this.environment = this.globals;
         this.locals = new Map();
 
-        this.globals = loadGlobalLib(this.globals);
+        this.globals = loadGlobalLib(this, this.globals);
     }
 
     resolve(expr, depth) {
@@ -49,9 +49,12 @@ module.exports = class Interpreter {
     }
 
     isTruthy(object) {
-        if (object === null) return false;
-        else if (typeof object === "boolean") return Boolean(object);
-        else return true;
+        if (object === null) 
+            return false;
+        if (typeof object === "boolean") 
+            return Boolean(object);
+        
+        return true;
     }
 
     checkNumberOperand(operator, operand) {
@@ -76,8 +79,10 @@ module.exports = class Interpreter {
     }
 
     isEqual(left, right) {
-        if (left === null && right === null) return true;
-        else if (left === null) return false;
+        if (left === null && right === null) 
+            return true;
+        if (left === null) 
+            return false;
 
         return left === right;
     }

--- a/src/lib/globalLib.js
+++ b/src/lib/globalLib.js
@@ -1,117 +1,147 @@
-const RuntimeError = require("../errors.js").RuntimeError;
-const EguaFunction = require("../structures/function.js");
-const EguaInstance = require("../structures/instance.js");
-const StandardFn = require("../structures/standardFn.js");
-const EguaClass = require("../structures/class.js");
+const RuntimeError = require("../errors.js").RuntimeError,
+    EguaFunction = require("../structures/function.js"),
+    EguaInstance = require("../structures/instance.js"),
+    StandardFn = require("../structures/standardFn.js"),
+    EguaClass = require("../structures/class.js");
 
 
-module.exports = function (globals) {
-  globals.defineVar(
-    "tamanho",
-    new StandardFn(1, function (obj) {
-      if (!isNaN(obj)) {
-        throw new RuntimeError(
-          this.token,
-          "Não é possível encontrar o tamanho de um número."
-        );
-      }
+module.exports = function (interpreter, globals) {
+    globals.defineVar(
+        "tamanho",
+        new StandardFn(1, function (obj) {
+            if (!isNaN(obj)) {
+                throw new RuntimeError(
+                    this.token,
+                    "Não é possível encontrar o tamanho de um número."
+                );
+            }
 
-      if (obj instanceof EguaInstance) {
-        throw new RuntimeError(
-          this.token,
-          "Você não pode encontrar o tamanho de uma declaração."
-        );
-      }
+            if (obj instanceof EguaInstance) {
+                throw new RuntimeError(
+                    this.token,
+                    "Você não pode encontrar o tamanho de uma declaração."
+                );
+            }
 
-      if (obj instanceof EguaFunction) {
-        return obj.declaration.params.length;
-      }
+            if (obj instanceof EguaFunction) {
+                return obj.declaration.params.length;
+            }
 
-      if (obj instanceof StandardFn) {
-        return obj.arityValue;
-      }
+            if (obj instanceof StandardFn) {
+                return obj.arityValue;
+            }
 
-      if (obj instanceof EguaClass) {
-        let methods = obj.methods;
-        let length = 0;
+            if (obj instanceof EguaClass) {
+                let methods = obj.methods;
+                let length = 0;
 
-        if (methods.init && methods.init.isInitializer) {
-          length = methods.init.declaration.params.length;
-        }
+                if (methods.init && methods.init.isInitializer) {
+                    length = methods.init.declaration.params.length;
+                }
 
-        return length;
-      }
+                return length;
+            }
 
-      return obj.length;
-    })
-  );
+            return obj.length;
+        })
+    );
 
-  globals.defineVar(
-    "texto",
-    new StandardFn(1, function (value) {
-      return `${value}`;
-    })
-  );
+    globals.defineVar(
+        "texto",
+        new StandardFn(1, function (value) {
+            return `${value}`;
+        })
+    );
 
-  globals.defineVar(
-    "real",
-    new StandardFn(1, function (value) {
-      if (!/^-{0,1}\d+$/.test(value) && !/^\d+\.\d+$/.test(value))
-        throw new RuntimeError(
-          this.token,
-          "Somente números podem passar para real."
-        );
-      return parseFloat(value);
-    })
-  );
+    globals.defineVar(
+        "real",
+        new StandardFn(1, function (value) {
+            if (!/^-{0,1}\d+$/.test(value) && !/^\d+\.\d+$/.test(value))
+                throw new RuntimeError(
+                    this.token,
+                    "Somente números podem passar para real."
+                );
+            return parseFloat(value);
+        })
+    );
 
-  globals.defineVar(
-    "inteiro",
-    new StandardFn(1, function (value) {
-      if (value === undefined || value === null) {
-        throw new RuntimeError(
-          this.token,
-          "Somente números podem passar para inteiro."
-        );
-      }
+    globals.defineVar(
+        "inteiro",
+        new StandardFn(1, function (value) {
+            if (value === undefined || value === null) {
+                throw new RuntimeError(
+                    this.token,
+                    "Somente números podem passar para inteiro."
+                );
+            }
 
-      if (!/^-{0,1}\d+$/.test(value) && !/^\d+\.\d+$/.test(value)) {
-        throw new RuntimeError(
-          this.token,
-          "Somente números podem passar para inteiro."
-        );
-      }
+            if (!/^-{0,1}\d+$/.test(value) && !/^\d+\.\d+$/.test(value)) {
+                throw new RuntimeError(
+                    this.token,
+                    "Somente números podem passar para inteiro."
+                );
+            }
 
-      return parseInt(value);
-    })
-  );
+            return parseInt(value);
+        })
+    );
 
-  globals.defineVar(
-    "ordenar", 
-    new StandardFn(1, function(obj){     
-      if (Array.isArray(obj) == false) {
-        throw new RuntimeError(
-          this.token,
-          "Valor Inválido. Objeto inserido não é um vetor."
-        );
-      }
+    globals.defineVar(
+        "ordenar",
+        new StandardFn(1, function (obj) {
+            if (Array.isArray(obj) == false) {
+                throw new RuntimeError(
+                    this.token,
+                    "Valor Inválido. Objeto inserido não é um vetor."
+                );
+            }
 
-      let trocado;
-      let length = obj.length;
-      do{
-        trocado = false;
-        for(var i = 0; i < length-1; i++){
-          if( obj[i] > obj[i+1] ){          
-            [obj[i], obj[i+1]] = [obj[i+1], obj[i]];
-            trocado = true;           
-          }
-        }
-      }while(trocado);         
-      return obj;
-    })
-  );
-  
-  globals.defineVar("exports", {});
+            let trocado;
+            let length = obj.length;
+            do {
+                trocado = false;
+                for (var i = 0; i < length - 1; i++) {
+                    if (obj[i] > obj[i + 1]) {
+                        [obj[i], obj[i + 1]] = [obj[i + 1], obj[i]];
+                        trocado = true;
+                    }
+                }
+            } while (trocado);
+            return obj;
+        })
+    );
 
-  return globals;
+    globals.defineVar(
+        "mapear",
+        new StandardFn(1, function (array, callback) {
+            if (!Array.isArray(array)) {
+                throw new RuntimeError(
+                    this.token,
+                    "Parâmetro inválido. O primeiro parâmetro da função, deve ser um array."
+                );
+            }
+
+            if (callback.constructor.name !== 'EguaFunction') {
+                throw new RuntimeError(
+                    this.token,
+                    "Parâmetro inválido. O segundo parâmetro da função, deve ser uma função."
+                );
+            }
+
+            let provisorio = [];
+            for (let index = 0; index < array.length; ++index) {
+                provisorio.push(
+                    callback.call(
+                        interpreter, [array[index]]
+                    )
+                );
+            }
+
+            return provisorio;
+        })
+    );
+
+    globals.defineVar("exports", {});
+
+    return globals;
 };

--- a/src/structures/function.js
+++ b/src/structures/function.js
@@ -2,7 +2,7 @@ const Callable = require("./callable.js");
 const Environment = require("../environment.js");
 const ReturnExpection = require("../errors.js").ReturnException;
 
-module.exports =  class EguaFunction extends Callable {
+module.exports = class EguaFunction extends Callable {
     constructor(name, declaration, closure, isInitializer = false) {
         super();
         this.name = name;


### PR DESCRIPTION
- Resolve #38;
- Função mapear em globalLib;
- Interpretador inicializa globalLib passando a si mesmo como argumento;
- Ajustes de indentação e boilerplates.