### PR TITLE
correção visual nos options

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -31,7 +31,7 @@ const clearOutput = function() {
 const editor = new CodeFlask("#editor", {
   language: 'js',
   lineNumbers: true,
-  defaultTheme: false 
+  defaultTheme: false
 });
 
 clearOutput();
@@ -41,8 +41,14 @@ function loadDemo(name) {
   editor.updateCode(demos[name]);
 }
 
-demoKeys.forEach(demo => {
+demoKeys.forEach((demo, index) => {
   const option = document.createElement("option");
+  if (index === 0) {
+    option.disabled = true;
+    option.selected = true;
+    option.hidden = true;
+  }
+
   option.textContent = demo.capitalize();
   option.value = demo;
   demoSelector.appendChild(option);


### PR DESCRIPTION
realizei a correção nos options, desabilitando a opção "exemplo
![Captura de tela 2021-10-07 134727](https://user-images.githubusercontent.com/26334984/136429070-d2b5103f-07d8-49f8-8d18-25ebe0e18226.png)
s
![Captura de tela 2021-10-07 134753](https://user-images.githubusercontent.com/26334984/136429080-2924330f-6d5d-4193-a82c-bee25ff9ccaa.png)
"