### PR TITLE
Alteração do código para permitir importar qualquer bilioteca JavaScript do Node.js

### DIFF
--- a/src/egua.js
+++ b/src/egua.js
@@ -95,7 +95,7 @@ module.exports.Egua = class Egua {
                 );
             else console.error(`Erro: [Linha: ${error.token.line}] ${error.message}`);
         } else {
-            console.error(error);
+            console.error(`Erro: ${error.message}`);
         }
         this.hadRuntimeError = true;
     }

--- a/src/lib/importStdlib.js
+++ b/src/lib/importStdlib.js
@@ -28,7 +28,7 @@ module.exports = function (name) {
             return loadModule("tempo", "./tempo.js");
         case "eguamat":
             return loadModule("eguamat", "./eguamat.js");
+        default:
+            return loadModule(name, name);
     }
-
-    return null;
 };

--- a/src/lib/importStdlib.js
+++ b/src/lib/importStdlib.js
@@ -1,8 +1,15 @@
-const StandardFn = require("../structures/standardFn.js");
-const EguaModule = require("../structures/module.js");
+const RuntimeError = require("../errors.js").RuntimeError,
+    StandardFn = require("../structures/standardFn.js"),
+    EguaModule = require("../structures/module.js");
 
 const loadModule = function (moduleName, modulePath) {
-    let moduleData = require(modulePath);
+    let moduleData;
+    try {
+        moduleData = require(modulePath);
+    } catch (erro) {
+        throw new RuntimeError(moduleName, `Biblioteca ${moduleName} não encontrada para importação.`);
+    }
+     
     let newModule = new EguaModule(moduleName);
 
     let keys = Object.keys(moduleData);


### PR DESCRIPTION
Motivação:

- Começar a separar nossas libs em outros módulos;
- Libs do Node que já estejam prontas podem ser usadas (estamos falando aqui de 1.3 milhão de pacotes);
- Oportunidade de usar Egua para aplicações comerciais, páginas Web, etc.