### PR TITLE
correção de drag de imagem

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -116,6 +116,11 @@ html {
   display: inline-block;
 }
 
+#middle img {
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
 #right {
   width: 25%;
   text-align: center;


### PR DESCRIPTION
Foi corrigido um bug na logo do projeto. Quando colocamos o mouse encima e arrastamos a imagem para o editor temos o seguinte problema:
![Captura de tela de 2022-10-15 20-27-59](https://user-images.githubusercontent.com/26334984/196011204-62d0b682-b258-45f4-bd19-4585fedc12cb.png)

A solução foi bem simples, bastando apenas desabilitar a seleção de usuario com Css.

