### PR TITLE
Permite avaliar código via texto

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,25 @@ const main = function () {
     let args = process.argv;
 
     const egua = new Egua();
-    if (args.length === 2) {
-        egua.runPrompt();
-    } else {
-        egua.runfile(args[2]);
+
+    switch (args.length) {
+        case 2:
+            egua.runPrompt();
+            break;
+        case 3:
+            egua.runfile(args[2]);
+            break;
+        case 4:
+            if (args[2] !== "avaliar") {
+                console.error(
+                    `Esperado parâmetro 'avaliar', recebido '${args[2]}'`
+                );
+                return;
+            }
+            egua.runstring(args[3]);
+            break;
+        default:
+            console.error("Número inválido de parâmetros");
     }
 };
 

--- a/src/egua.js
+++ b/src/egua.js
@@ -46,6 +46,15 @@ module.exports.Egua = class Egua {
         if (this.hadRuntimeError) process.exit(70);
     }
 
+    runstring(string) {
+        const interpreter = new Interpreter(this, process.cwd());
+
+        this.run(string, interpreter);
+
+        if (this.hadError) process.exit(65);
+        if (this.hadRuntimeError) process.exit(70);
+    }
+
     run(code, interpreter) {
         const lexer = new Lexer(code, this);
         const tokens = lexer.scan();


### PR DESCRIPTION
Permite avaliar código via texto, ex:

```egua
egua avaliar 'escreva("olá");'
olá
```