### PR TITLE
Migra publicação npm para Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-
-    # Trusted Publishing (OIDC): o npm aceita o publish deste workflow sem token,
-    # conforme configurado em npmjs.com > pacote egua > Settings > Trusted Publisher.
     permissions:
       contents: read
       id-token: write
@@ -19,7 +16,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        # Node 24 traz npm >= 11.5.1, requisito do Trusted Publishing
         node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,18 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Trusted Publishing (OIDC): o npm aceita o publish deste workflow sem token,
+    # conforme configurado em npmjs.com > pacote egua > Settings > Trusted Publisher.
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '22.x'
+        # Node 24 traz npm >= 11.5.1, requisito do Trusted Publishing
+        node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Instalando dependências
@@ -24,8 +31,6 @@ jobs:
 
     - name: Publicando NPM
       run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   tests_package:
     runs-on: ubuntu-latest
@@ -35,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '22.x'
+        node-version: '24.x'
 
     - name: Funcionamento de pacote
       run: |

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/eguadev/egua.git"
   },
   "bin": {
-    "egua": "./bin/egua"
+    "egua": "bin/egua"
   },
   "keywords": [
     "egua"


### PR DESCRIPTION
## Problema

A release v1.3.10 falhou com `E404 Not Found - PUT https://registry.npmjs.org/egua`. A versão não é o problema (a 1.3.10 está livre; latest é 1.3.9): esse 404 é como o registry responde a **autenticação inválida**. O npm [revogou permanentemente todos os classic tokens em 09/12/2025](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/) e limitou tokens granulares de escrita a 90 dias — o secret `NPM_TOKEN` está morto.

## Solução

[Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers/): o GitHub Actions se autentica direto no registry, sem nenhum token armazenado para expirar ou vazar, e o npm gera **provenance** automaticamente (selo de procedência na página do pacote).

- `permissions: id-token: write` no job de publish
- Node 24 (traz npm ≥ 11.5.1, requisito do trusted publishing)
- `NODE_AUTH_TOKEN`/secret não são mais necessários
- Normaliza `bin` no package.json via `npm pkg fix` (remove o warning do publish)

## Pós-merge (manual)

1. Em npmjs.com → pacote `egua` → **Settings → Trusted Publisher**: GitHub Actions, org `eguadev`, repo `egua`, workflow `publish.yml`, environment em branco.
2. Recriar a tag na main atualizada:
   ```
   git tag -d v1.3.10 && git push origin :refs/tags/v1.3.10
   git checkout main && git pull
   git tag v1.3.10 && git push origin v1.3.10
   ```
