### PR TITLE
Adiciona builds do bundle da IDE e do site ao workflow de CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Commit e PR - Main
 on:
   push:
     branches:
-       - "*"
+      - "*"
   pull_request:
     branches:
       - "*"
@@ -23,3 +23,21 @@ jobs:
 
     - name: Teste binário
       run: npm run test
+
+    - name: Build do bundle da IDE (egua.min.js)
+      run: npm run build-web
+
+  site:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Build do site (VitePress)
+      working-directory: apps/site
+      run: |
+        npm ci
+        npm run build


### PR DESCRIPTION
## Resumo
- Adiciona o build do bundle da IDE (`npm run build-web` → `egua.min.js`) ao job `tests` do workflow de CI
- Adiciona job `site` que builda o site VitePress (`apps/site`) com `npm ci && npm run build`

Garante que qualquer alteração no interpretador ou no site seja validada pelo CI antes do merge.

## Validação
- Rodado localmente: testes do binário (0 erros), `build-web` e build do VitePress, todos com sucesso
- CI verde no push: https://github.com/eguadev/egua/actions/runs/29301608792